### PR TITLE
Update _colours-palette.scss

### DIFF
--- a/packages/idsk-frontend/src/govuk/settings/_colours-palette.scss
+++ b/packages/idsk-frontend/src/govuk/settings/_colours-palette.scss
@@ -26,7 +26,7 @@ $govuk-colours: (
   "pink": #d53880,
 
   "light-pink": #f499be,
-  "orange": #f47738,
+  "orange": #D96E00,
   "brown": #b58840,
   // "light-green": #85994b,
   // Neutral palette


### PR DESCRIPTION
"Tlačidlo v komponentoch má nastavenú farbu focusu na #F47738.  Podľa prílohy č. 12 má byť focus #D96E00"