### PR TITLE
Oprava font-faces.scss, material-icons font path obsahoval '//'

### DIFF
--- a/packages/idsk-frontend/src/govuk/helpers/_font-faces.scss
+++ b/packages/idsk-frontend/src/govuk/helpers/_font-faces.scss
@@ -54,8 +54,8 @@
   font-weight: 400;
   font-display: block;
   src:
-    govuk-font-url("/material-icon/material-icons.woff2") format("woff2"),
-    govuk-font-url("/material-icon/material-icons.woff") format("woff");
+    govuk-font-url("material-icon/material-icons.woff2") format("woff2"),
+    govuk-font-url("material-icon/material-icons.woff") format("woff");
 }
 
 .material-icons {
@@ -82,8 +82,8 @@
   font-weight: 400;
   font-display: block;
   src:
-    govuk-font-url("/material-icon/material-icons-outlined.woff2") format("woff2"),
-    govuk-font-url("/material-icon/material-icons-outlined.woff") format("woff");
+    govuk-font-url("material-icon/material-icons-outlined.woff2") format("woff2"),
+    govuk-font-url("material-icon/material-icons-outlined.woff") format("woff");
 }
 
 .material-icons-outlined {


### PR DESCRIPTION
CSS import path na material icons font obsahoval '//', kvôli spájaní dvoch paths, ktoré mali na konci aj začiatku '/'. Chyba nie je pri developmente viditeľná, až v produkcii, z nejakých mne neznámych dôvodov.